### PR TITLE
chore: ignore JDT.LS output and AI tool workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,13 @@ hs_err_pid*
 .classpath
 .project
 .settings
+# Eclipse / VSCode Java (JDT.LS) compile output
+bin/
+*.factorypath
+
+# AI tool workspaces
+.claude/
+.opencode/
 
 #Intellij
 .idea/


### PR DESCRIPTION
## Why
When the repo is opened in VSCode with the Red Hat Java extension (or Eclipse with Buildship), the Eclipse JDT language server generates per-module `bin/` output directories (`bin/main`, `bin/test`, `bin/generated-sources`, ...) and `.factorypath` files for annotation processing. They are not produced by Gradle, are not tracked by git, and clutter `git status` across every submodule.

This branch also ignores `.claude/` and `.opencode/` workspaces created by local AI tooling.

## What
Add to `.gitignore`:
- `bin/` and `*.factorypath` under the existing `#eclipse` section.
- `.claude/` and `.opencode/` under a new `# AI tool workspaces` section.

## Notes
- No tracked files are affected (`git ls-files` under any `bin/` returned 0 before the change).
- Local cleanup of 152 stray `bin/` directories was done outside this PR; this change only prevents them from showing up in `git status` going forward.